### PR TITLE
Fixes for Kirby 2.2

### DIFF
--- a/assets/js/tabs.js
+++ b/assets/js/tabs.js
@@ -1,18 +1,21 @@
 (function($) {
-  $(document).ready(function() {
 
-    if (app && typeof app == 'object') {
-      $(app.main).on('view:load', initModalModules);
-    }
+  var Tab = function(element) {
 
-    function initModalModules() 
-	{  
+    var self = this;
+
+    // basic elements and stuff
+    this.tab = $(element);
+
+    // init
+    this.init = function () {
+
 		if ($('.fieldset input.tabfield').length)
 		{
 		  if ($(".fieldset").length)
 		  {
-			  $('.fieldset').removeClass("fieldset-fixed");
-			  $(".fieldset").prepend($("<ul></ul>").addClass("tabs"));
+			$('.fieldset').first().removeClass("fieldset-fixed");
+			$(".fieldset").first().prepend($("<ul></ul>").addClass("tabs"));
 		  }
 
 		  else{
@@ -20,6 +23,12 @@
 		  }
 
 		  $('.fieldset label.tabfield').each(function() {
+		  	var name = $(this).children()[0].name;
+		  	$('[name="'+name+'"]').each(function(i,v) {
+		  		if(i!==0) {
+		  			$(this).remove();
+		  		}
+		  	});
 			var title = "<li class='tab' href='" + $(this).attr('name') + "'>" + $(this).closest(".field-grid-item").text().trim() + "</li>";
 			$(".tabs").append(title);
 		  });
@@ -55,8 +64,28 @@
 		  });
 		
 		}
-    }
 
+    };
 
-  });
-}(jQuery));
+    // start the plugin
+    return this.init();
+
+  };
+
+  // jquery helper for the tab plugin
+  $.fn.tabfield = function() {
+
+    return this.each(function(i,v) {
+      if($(this).data('tabfield')) {
+        return $(this).data('tabfield');
+      } else {
+        var tab = new Tab(this);
+        $(this).data('tabfield', tab);
+        return tab;
+      }
+
+    });
+
+  };
+
+})(jQuery);

--- a/tabs.php
+++ b/tabs.php
@@ -32,6 +32,7 @@ class TabsField extends InputField
     $wrapper->attr('for', $this->id());
     $wrapper->removeAttr('id');
     $wrapper->addClass('tabfield');
+    $wrapper->attr('data-field','tabfield');
     $wrapper->prepend($input);
 
     return $wrapper;
@@ -46,7 +47,7 @@ class TabsField extends InputField
   }
 
   public function validate() {
-    return v::accepted($this->value());
+    return true;
   }
 
 }


### PR DESCRIPTION
Referencing [this issue](https://github.com/afbora/Kirby-Tabs-Field/issues/2):

This still has an issue where there's a flash of the unstyled tabs within a structure field when the structure field first opens, and the fixes added aren't super-elegant, but these edits have the tabs field working in Kirby 2.2 without any validation errors on page saving.
