### PR TITLE
Sticky Navigation Fix

### DIFF
--- a/assets/css/tabs.css
+++ b/assets/css/tabs.css
@@ -7,6 +7,8 @@
   position: relative;
   background: #EFEFEF;
   z-index: 10;
+  padding-top: 1.5em;
+  margin-top: -1.5em;
 }
 
 .modal-content .tab-nav {


### PR DESCRIPTION
When I was adjusting the styles I didn’t check in Safari, where the -webkit-sticky let’s the tabs float on the top.

Now I’ve added a padding and a negative margin to maintain the position.
