### PR TITLE
Corrected JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,5 +8,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/afbora/Kirby-Tabs-Field"
-  },
+  }
 }


### PR DESCRIPTION
That trailing comma invalidated the JSON, therefore PHP couldn't parse the file and the Kirby CLI couldn't install this field. 
I've removed the comma.