### PR TITLE
Corrected name in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Kirby-Tabs-Field",
+  "name": "tabs",
   "description": "The tab field type is designed specifically for use within the fields.",
   "author": "Ahmet Bora <byybora@gmail.com>",
   "version": "1.5",


### PR DESCRIPTION
Sorry... Didn't see this earlier. The `name` needs to be "tabs" in your case. The CLI uses that to set the folder name.