### PR TITLE
Update tabs.js

### DIFF
--- a/assets/js/tabs.js
+++ b/assets/js/tabs.js
@@ -16,8 +16,12 @@ var TAB_CONTAINER_CLASS  = "tab-container";    // Class for each tab container
 /***********************/
 $.fn.tabs = function() {
    // sessionStorage key for the currently active tab
-   var CURRENT_TAB_STORAGE  = "tabs" + window.location.pathname;
+   var CURRENT_TAB_STORAGE  = (function() {
+    var pathName = window.location.pathname;
 
+    return "tabs"+ pathName.replace(/\/page:[0-9]+/,"");
+  }());
+   
    /**********************************/
    /* Handle clicks on the tab links */
    /**********************************/


### PR DESCRIPTION
When you have a paginator the current tab gets forgotten. This is due to the fact the current tab is stored in localstorage  by using the window.location.pathname. This changes when you use the pager. /page:2 gets added and so the code doesn't know what the state was. 
In this pr i stripped the page param from the url and its all working correctly.